### PR TITLE
remove setinterval

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,13 +28,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <video
-      id="webcam"
-      autoplay
-      playsinline
-      width="640"
-      height="480"
-      style="visibility: hidden"
-    ></video>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -8,10 +8,9 @@ import { Search } from "./Search";
 function App() {
   const [eyesClosed, setEyesClosed] = useState(false);
   const videoRef = useRef(null);
-  const modelRef = useRef(null);
+  const detectorRef = useRef(null);
 
   const initTensorFlow = async () => {
-    // Start your camera feed or video source here
     const video = videoRef.current;
     const stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
@@ -20,23 +19,23 @@ function App() {
       },
     });
     video.srcObject = stream;
-    // load model
     const detectorConfig = {
       runtime: "mediapipe", // or 'tfjs'
       solutionPath: "https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh",
     };
-    modelRef.current = await fld.createDetector(
+    detectorRef.current = await fld.createDetector(
       fld.SupportedModels.MediaPipeFaceMesh,
       detectorConfig
     );
   };
   const animate = async () => {
-    // console.log("video in animate", videoRef.current);
-    let stuff = await detectEyeClosure(modelRef.current, videoRef.current);
-    const { closed, detector } = stuff;
+    const { closed } = await detectEyeClosure(
+      detectorRef.current,
+      videoRef.current
+    );
     setEyesClosed(closed);
-    await tf.nextFrame(); // Wait for the next animation frame
-    requestAnimationFrame(animate); // Continue the animation loop
+    await tf.nextFrame();
+    requestAnimationFrame(animate);
   };
   useEffect(() => {
     initTensorFlow(); // Initialize TensorFlow and start the animation loop

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
+  // strict mode breaks detector generation b/c you can only have one
+  // strict mode causes us to attempt to generate 2 detectors, breaking the app
   // <React.StrictMode>
   <App />
   // </React.StrictMode>,

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/tf.js
+++ b/src/tf.js
@@ -17,11 +17,11 @@ const leftEyeKeyPoints = (keypoints) => {
   };
 };
 
-export const detectEyeClosure = async (model, video) => {
-  if (!model || !video) {
+export const detectEyeClosure = async (detector, video) => {
+  if (!detector || !video) {
     return {};
   }
-  const faces = await model.estimateFaces(video);
+  const faces = await detector.estimateFaces(video);
   let obj = {};
   if (faces && faces.length > 0) {
     faces.forEach(({ keypoints }) => {


### PR DESCRIPTION
setInterval doesnt work well on ios. it would only run once. it may be becasue it triggered some sort of error immediately that didn't crash the application.
was really hard to debug because i didn't have xcode lol.

this PR:
- converts from setInterval to recursive video processing
- converts webcam tag from html to jsx
- removes strict mode (comments added as to why) because generating 2 detectors breaks the app (limitation of tensorflow).