### PR TITLE
Enable refineLandmarks. Refactor detectEyeClosure

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,19 @@ import * as tf from "@tensorflow/tfjs";
 import * as fld from "@tensorflow-models/face-landmarks-detection";
 import { Search } from "./Search";
 
+const USER_MEDIA_CONSTRAINTS = {
+  audio: false,
+  video: {
+    facingMode: "user",
+  },
+};
+
+const DETECTOR_CONFIG = {
+  runtime: "mediapipe", // or 'tfjs'
+  solutionPath: "https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh",
+  refineLandmarks: true,
+};
+
 function App() {
   const [eyesClosed, setEyesClosed] = useState(false);
   const videoRef = useRef(null);
@@ -12,24 +25,19 @@ function App() {
 
   const initTensorFlow = async () => {
     const video = videoRef.current;
-    const stream = await navigator.mediaDevices.getUserMedia({
-      audio: false,
-      video: {
-        facingMode: "user",
-      },
-    });
+    const stream = await navigator.mediaDevices.getUserMedia(
+      USER_MEDIA_CONSTRAINTS
+    );
     video.srcObject = stream;
-    const detectorConfig = {
-      runtime: "mediapipe", // or 'tfjs'
-      solutionPath: "https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh",
-    };
+
     detectorRef.current = await fld.createDetector(
       fld.SupportedModels.MediaPipeFaceMesh,
-      detectorConfig
+      DETECTOR_CONFIG
     );
   };
+
   const animate = async () => {
-    const { closed } = await detectEyeClosure(
+    const closed = await detectEyeClosure(
       detectorRef.current,
       videoRef.current
     );
@@ -37,9 +45,11 @@ function App() {
     await tf.nextFrame();
     requestAnimationFrame(animate);
   };
+
   useEffect(() => {
     initTensorFlow(); // Initialize TensorFlow and start the animation loop
   }, []);
+
   return (
     <div className="App">
       <video

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ function App() {
   };
 
   const animate = async () => {
-    const closed = await detectEyeClosure(
+    const { closed } = await detectEyeClosure(
       detectorRef.current,
       videoRef.current
     );

--- a/src/tf.js
+++ b/src/tf.js
@@ -20,15 +20,15 @@ const leftEyeKeyPoints = (keypoints) => {
 
 export const detectEyeClosure = async (detector, video) => {
   if (!detector || !video) {
-    return false;
+    return { closed: false };
   }
   const faces = await detector.estimateFaces(video);
 
   if (!faces || faces.length === 0) {
-    return false;
+    return { closed: false };
   }
 
-  return faces.every((face) => {
+  const closed = faces.every((face) => {
     const { keypoints } = face;
 
     const rightEAR = calculateEAR(rightEyeKeyPoints(keypoints));
@@ -37,6 +37,7 @@ export const detectEyeClosure = async (detector, video) => {
     // true if both eyes are closed
     return leftEAR <= EAR_THRESHOLD && rightEAR <= EAR_THRESHOLD;
   });
+  return { closed };
 };
 
 function euclideanDistance(point1, point2) {

--- a/src/tf.js
+++ b/src/tf.js
@@ -1,4 +1,5 @@
-const EAR_THRESHOLD = 0.2;
+// Average EAR for eyes open is 0.141 and for eyes closed is 0.339
+const EAR_THRESHOLD = 0.141;
 
 const rightEyeKeyPoints = (keypoints) => {
   return {
@@ -19,23 +20,23 @@ const leftEyeKeyPoints = (keypoints) => {
 
 export const detectEyeClosure = async (detector, video) => {
   if (!detector || !video) {
-    return {};
+    return false;
   }
   const faces = await detector.estimateFaces(video);
-  let obj = {};
-  if (faces && faces.length > 0) {
-    faces.forEach(({ keypoints }) => {
-      const rightEAR = calculateEAR(rightEyeKeyPoints(keypoints));
-      const leftEAR = calculateEAR(leftEyeKeyPoints(keypoints));
 
-      // True if the eye is closed
-      const closed = leftEAR <= EAR_THRESHOLD && rightEAR <= EAR_THRESHOLD;
-      obj = {
-        closed,
-      };
-    });
+  if (!faces || faces.length === 0) {
+    return false;
   }
-  return obj;
+
+  return faces.every((face) => {
+    const { keypoints } = face;
+
+    const rightEAR = calculateEAR(rightEyeKeyPoints(keypoints));
+    const leftEAR = calculateEAR(leftEyeKeyPoints(keypoints));
+
+    // true if both eyes are closed
+    return leftEAR <= EAR_THRESHOLD && rightEAR <= EAR_THRESHOLD;
+  });
 };
 
 function euclideanDistance(point1, point2) {


### PR DESCRIPTION
> refineLandmarks: Defaults to false. If set to true, refines the landmark coordinates around the eyes and lips, and output additional landmarks around the irises.

Docs: https://github.com/tensorflow/tfjs-models/tree/master/face-landmarks-detection/src/mediapipe#create-a-detector

Also, refactoring `detectEyeClosure` to return a boolean to keep it simple. Currently, it sometimes returns `closed: undefined` and other times - `closed: false`. These two should not be different values, it causes unnecessary re-rendering.