### PR TITLE
shrink video instead of hiding to enable on safari

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,13 +54,13 @@ function App() {
     <div className="App">
       <video
         ref={videoRef}
-        width="640"
-        height="480"
+        width="1"
+        height="1"
         autoPlay
         playsInline
         muted
         onLoadedMetadata={animate}
-        style={{ visibility: "hidden", position: "absolute" }}
+        style={{ position: "absolute" }}
       />
       <Search eyesClosed={eyesClosed} />
     </div>


### PR DESCRIPTION
safari needs the video to be visible on the screen in order to run analysis on the webcam component.

my compromise is to render it with 1 px height and width. it's still there but not really noticeable
<img width="35" alt="Screenshot 2023-10-24 at 12 20 47 PM" src="https://github.com/yogurtandjam/the-blind-museum/assets/37092291/85004432-c61d-492f-9f1a-7807a5be3bb9">
