### PR TITLE
make camera fixed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,7 +60,7 @@ function App() {
         playsInline
         muted
         onLoadedMetadata={animate}
-        style={{ position: "absolute" }}
+        style={{ position: "fixed" }}
       />
       <Search eyesClosed={eyesClosed} />
     </div>


### PR DESCRIPTION
fixes a bug that allowed users to bypass the camera check.

with absolute positioning the webcam component could be scrolled out of view if there were enough pieces of art rendered. this would cause any changes in face state to not be registered because the camera component is not being rendered on screen.